### PR TITLE
Update backup.php

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -79,7 +79,7 @@ class Backup
                 $columnsData = [];
                 foreach ($rows as $row) {
                     $row = array_map(function ($item) {
-                        return $this->db->quote($item);
+                         return $this->db->quote($item === null ? '' : $item); // null değerleri boş string ile değiştir php 8 sonrası için 
                     }, $row);
                     $columnsData[] = '(' . implode(',', $row) . ')';
                 }


### PR DESCRIPTION
PHP 8 sonrasındaki Deprecated: PDO::quote(): Passing null to parameter #1 ($string) of type string is deprecated hatasi fix